### PR TITLE
Add MI 4.6.0 to products list

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -20,7 +20,8 @@
             "tagName": "v1.0.0",
             "products": [
                 "MI 4.4.0",
-                "MI 4.5.0"
+                "MI 4.5.0",
+                "MI 4.6.0"
             ],
             "operations": [],
             "connections": [],


### PR DESCRIPTION
This PR adds MI 4.6.0 to the products list for releases that already contain MI 4.5.0, ensuring compatibility with the new Micro Integrator version.